### PR TITLE
fix: update the chart to use the new repository for smtp

### DIFF
--- a/charts/smtp/Chart.yaml
+++ b/charts/smtp/Chart.yaml
@@ -1,16 +1,16 @@
 apiVersion: v2
 name: smtp
 description: exim based smtp smarthost / mail relay
-home: https://github.com/ix-ai/smtp
+home: https://gitlab.com/egos-tech/smtp
 type: application
 
 # This is the chart version. This version number should be
 # incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.2
+version: 2.1.3
 
 # This is the version number of the application being deployed.
-appVersion: v0.5.2
+appVersion: 1.0.1
 
 annotations:
   artifacthub.io/changes: |

--- a/charts/smtp/README.md
+++ b/charts/smtp/README.md
@@ -1,6 +1,6 @@
 # smtp
 
-This chart installs an [smtp daemon](https://github.com/ix-ai/smtp) in
+This chart installs an [smtp daemon](https://gitlab.com/egos-tech/smtp) in
 kubernetes to work as a mail relay.
 
 The recommended approach is to configure it with authentication to a
@@ -12,9 +12,9 @@ namespace) send mail to this relay.
 Add a `config:` key to your values.yaml override (or helm `--set` parameters) with the necessary values (without the # prefix for the
 values you set):
 
-```
+```yml
 config:
-  # See documentation at https://github.com/ix-ai/smtp#readme
+  # See documentation at https://gitlab.com/egos-tech/smtp#smtp
   #SMARTHOST_ADDRESS: mail.example.com
   #SMARTHOST_PORT: "587"
   #SMARTHOST_USER: myuser
@@ -32,4 +32,4 @@ SMARTHOST_ALIASES setting.
 
 You can also use Gmail or Amazon SES with just a couple of
 configuration values as described in the
-[ix-ai/smtp](https://github.com/ix-ai/smtp#smtp) documentation.
+[egos-tech/smtp](https://gitlab.com/egos-tech/smtp#smtp) documentation.

--- a/charts/smtp/templates/deployment.yaml
+++ b/charts/smtp/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
           - secretRef:
-              name: {{ template "smtp.fullname" . }}-secrets    
+              name: {{ template "smtp.fullname" . }}-secrets
           ports:
             - name: smtp
               containerPort: 25

--- a/charts/smtp/values.yaml
+++ b/charts/smtp/values.yaml
@@ -3,19 +3,15 @@
 replicaCount: 1
 
 image:
-  # github container registry
-  repository: ghcr.io/ix-ai/smtp
-  # docker hub
-  # repository: ixdotai/smtp
   # gitlab registry
-  # repository: registry.gitlab.com/ix.ai/smtp
+  repository: registry.gitlab.com/egos-tech/smtp
   pullPolicy: IfNotPresent
 
 # name of existing secret with an smtp config
 existingSecret:
 
 # any variables supported by ix-ai/smtp can be added here
-# see https://github.com/ix-ai/smtp#readme for a full list
+# see https://gitlab.com/egos-tech/smtp#smtp for a full list
 config:
   #MAILNAME: smtp
   DISABLE_IPV6: "1"


### PR DESCRIPTION
This PR updates the `smtp` chart to use the new repository.

It also updates the image to the latest version available.

Ref: https://github.com/ix-ai/smtp/commit/a58d21a2dc49c5ee7fbd6c32e718aa2a0536a090