### PR TITLE
support for configurable volumes and mounts for mounting DKIM private key

### DIFF
--- a/charts/smtp/templates/deployment.yaml
+++ b/charts/smtp/templates/deployment.yaml
@@ -51,6 +51,14 @@ spec:
             periodSeconds: 60
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.extraVolumeMounts }}
+          volumeMounts:
+          {{- toYaml .Values.extraVolumeMounts | nindent 10 }}
+          {{- end }}
+      {{- if .Values.extraVolumes }}
+      volumes:
+      {{- toYaml .Values.extraVolumes | nindent 6 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Hello ntppool team,
We are using smtp in customer deployments (In Kubernetes) as a temporary solution until they set up their own. Recently, we found ourself in need of setting this up for somebody as a permanent solution and needed to implement DKIM so the e-mails relayed did not end up in Spam. I could not find anywhere in your documentation how to set it up in Kubernetes, so I had added support for mounting volumes as a way to pass the DKIM private key into the pod.
We would appreciate if you would accept this change into upstream so we don't have to maintain this fork.

Thank you for your time.